### PR TITLE
Slack support url

### DIFF
--- a/index.html
+++ b/index.html
@@ -46,7 +46,7 @@
                 <ul>
                     <li><a href=https://github.com/dataproofer/Dataproofer#getting-started><i class="fa fa-download" aria-hidden=true></i> How to install</a></li>
                     <li><a href=https://github.com/dataproofer/Dataproofer#creating-a-new-test><i class="fa fa-file-code-o" aria-hidden=true></i> Writing a test</a></li>
-                    <li><a href=https://dataproofer.slack.com/signup><i class="fa fa-slack" aria-hidden=true></i> Slack Support</a></li>
+                    <li><a href=https://newsnerdery.slack.com/messages/dataproofer><i class="fa fa-slack" aria-hidden=true></i> Slack</a> <small>via <a href=http://newsnerdery.org/>News Nerdery</a></small></li>
                 </ul>
             </div>
         </section>

--- a/style.css
+++ b/style.css
@@ -37,7 +37,7 @@ a:hover,a:visited{color:#000;opacity:.5;-ms-filter:"progid:DXImageTransform.Micr
 .use-section#documentation{background-color:#c8dff3}
 .use-section#documentation h3{color:#fff;background-color:#2e94f6}
 #use-dataproofer .use-section{width:47%;display:inline-block;vertical-align:top;padding:1em;margin:1%;text-align:center}
-#use-dataproofer .use-section li{border-bottom:1px solid rgba(255,255,255,.2);padding:1em;font-size:1.5em;text-align:left;list-style-type:none}
+#use-dataproofer .use-section li{border-bottom:1px solid rgba(255,255,255,.2);padding:1em 0.5em;font-size:1.5em;text-align:left;list-style-type:none}
 #contact-us .contact-section{width:29%;display:inline-block;border:1px solid #000;margin:2%;overflow:hidden;text-align:center;padding:1em 0}
 #funding{text-align:center}
 @media only screen and (max-width:767px){#container{width:100%;max-width:720px;margin:0;padding:2px}


### PR DESCRIPTION
- sets slack support url to https://newsnerdery.slack.com/messages/dataproofer
- adds News Nerdery link http://newsnerdery.org/
- adjusts padding left and right on documentation list items to prevent early rag of text

Before:
![image](https://cloud.githubusercontent.com/assets/952321/19599141/283275b6-976d-11e6-8755-459e28eca5c2.png)

After:
![image](https://cloud.githubusercontent.com/assets/952321/19598860/2401a0c2-976b-11e6-9c87-735752113a89.png)
